### PR TITLE
Consume JDT LS extension

### DIFF
--- a/lsp4quarkus/src/main/java/lsp4quarkus/App.java
+++ b/lsp4quarkus/src/main/java/lsp4quarkus/App.java
@@ -1,12 +1,17 @@
 package lsp4quarkus;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.launch.LSPLauncher.Builder;
 import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 import lsp4quarkus.commons.ParentProcessWatcher;
 
@@ -20,7 +25,7 @@ public class App {
 		} else {
 			wrapper = new ParentProcessWatcher(server);
 		}
-    	Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(
+    	Launcher<LanguageClient> launcher = createServerLauncher(
     											server,
     											System.in, 
     											System.out,
@@ -29,5 +34,28 @@ public class App {
     	
     	server.setClient(launcher.getRemoteProxy());
     	launcher.startListening();
+	}
+	
+	/**
+	 * Create a new Launcher for a language server and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and outgoing message streams so additional
+	 * message handling such as validation and tracing can be included.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 */
+	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out,
+			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
+		return new Builder<LanguageClient>()
+				.setLocalService(server)
+				.setRemoteInterface(QuarkusLanguageClient.class) // Set client as Quarkus language client
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.create();
 	}
 }

--- a/lsp4quarkus/src/main/java/lsp4quarkus/ExtendedConfigDescriptionBuildItem.java
+++ b/lsp4quarkus/src/main/java/lsp4quarkus/ExtendedConfigDescriptionBuildItem.java
@@ -1,0 +1,61 @@
+package lsp4quarkus;
+
+public class ExtendedConfigDescriptionBuildItem {
+
+	private String propertyName;
+	private String type;
+	private String defaultValue;
+	private String docs;
+
+	private String source;
+	private Boolean required;
+
+	public String getPropertyName() {
+		return propertyName;
+	}
+
+	public void setPropertyName(String propertyName) {
+		this.propertyName = propertyName;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public String getDefaultValue() {
+		return defaultValue;
+	}
+
+	public void setDefaultValue(String defaultValue) {
+		this.defaultValue = defaultValue;
+	}
+
+	public String getDocs() {
+		return docs;
+	}
+
+	public void setDocs(String docs) {
+		this.docs = docs;
+	}
+
+	public String getSource() {
+		return source;
+	}
+
+	public void setSource(String source) {
+		this.source = source;
+	}
+
+	public Boolean isRequired() {
+		return required;
+	}
+
+	public void setRequired(Boolean required) {
+		this.required = required;
+	}
+
+}

--- a/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusLanguageClient.java
+++ b/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusLanguageClient.java
@@ -1,0 +1,13 @@
+package lsp4quarkus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+public interface QuarkusLanguageClient extends LanguageClient {
+
+	@JsonRequest("quarkus/properties")
+	CompletableFuture<List<ExtendedConfigDescriptionBuildItem>> getProperties();
+}

--- a/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusLanguageServer.java
+++ b/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusLanguageServer.java
@@ -25,10 +25,10 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 	private TextDocumentService textDocumentService;
 	private WorkspaceService workspaceService;
 	private Integer parentProcessId;
-	private LanguageClient languageClient;
+	private QuarkusLanguageClient languageClient;
 	
 	public QuarkusLanguageServer() {
-		textDocumentService = new QuarkusTextDocumentService();
+		textDocumentService = new QuarkusTextDocumentService(this);
 		workspaceService = new QuarkusWorkspaceService();
 	}
 
@@ -83,12 +83,12 @@ public class QuarkusLanguageServer implements LanguageServer, ProcessLanguageSer
 		return this.workspaceService;
 	}
 	
-	public LanguageClient getLanguageClient() {
+	public QuarkusLanguageClient getLanguageClient() {
 		return languageClient;
 	}
 	
 	public void setClient(LanguageClient languageClient) {
-		this.languageClient = languageClient;
+		this.languageClient = (QuarkusLanguageClient) languageClient;
 	}
 
 	@Override

--- a/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusTextDocumentService.java
+++ b/lsp4quarkus/src/main/java/lsp4quarkus/QuarkusTextDocumentService.java
@@ -19,8 +19,10 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 	
 	private static final Logger LOGGER = Logger.getLogger(QuarkusLanguageServer.class.getName());
 
-	public QuarkusTextDocumentService() {
-		LOGGER.info("Text document service instantiated");
+	private final QuarkusLanguageServer quarkusLanguageServer;
+	
+	public QuarkusTextDocumentService(QuarkusLanguageServer quarkusLanguageServer) {
+		this.quarkusLanguageServer = quarkusLanguageServer;
 	}
 	
 	public void didOpen(DidOpenTextDocumentParams params) {
@@ -46,18 +48,31 @@ public class QuarkusTextDocumentService implements TextDocumentService {
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
         LOGGER.info("Inside autocomplete");
-		final List<CompletionItem> completions = new ArrayList<>();
-        return CompletableFuture.supplyAsync(() -> {
-        	completions.add(new CompletionItem("quarkus.option1"));
-        	completions.add(new CompletionItem("quarkus.option2"));
-        	completions.add(new CompletionItem("quarkus.option3"));
-        	completions.add(new CompletionItem("quarkus.option4"));
-        	completions.add(new CompletionItem("quarkus.option5"));
-        	completions.add(new CompletionItem("quarkus.option6"));
-        	completions.add(new CompletionItem("quarkus.option7"));
-        	
+        return quarkusLanguageServer.getLanguageClient().getProperties().thenApplyAsync(properties -> {
+        	final List<CompletionItem> completions = new ArrayList<>();
+        	for (ExtendedConfigDescriptionBuildItem property : properties) {
+				completions.add(new CompletionItem(property.getPropertyName()));
+			}
         	return Either.forLeft(completions);
         });
+//        
+//        
+//		final List<CompletionItem> completions = new ArrayList<>();
+//        return CompletableFuture.supplyAsync(() -> {
+//        	// TODO: check the project is a Quarkus project
+//        	// TODO: store in cache properties
+//        	
+//        	
+//        	completions.add(new CompletionItem("quarkus.option1"));
+//        	completions.add(new CompletionItem("quarkus.option2"));
+//        	completions.add(new CompletionItem("quarkus.option3"));
+//        	completions.add(new CompletionItem("quarkus.option4"));
+//        	completions.add(new CompletionItem("quarkus.option5"));
+//        	completions.add(new CompletionItem("quarkus.option6"));
+//        	completions.add(new CompletionItem("quarkus.option7"));
+//        	
+//        	return Either.forLeft(completions);
+        //});
 	}
 
 }


### PR DESCRIPTION
Please note that vscode-quarkus need to be updated by adding after https://github.com/xorye/vscode-quarkus/blob/1c5eb08e2abd91d57d4b9c7806a0ad1fc6715256/src/extension.ts#L113

`languageClient.onRequest("quarkus/properties", (params: any) => commands.executeCommand('com.redhat.jdtls.quarkus.jdt.ls.quarkus.samplecommand', params)); `

This line intercept the custom client request type "quarkus/properties" and delegate the process of this request to the JDL LS extension for Quarkus.